### PR TITLE
feat : 기본 도메인 설계

### DIFF
--- a/src/main/java/com/book/librarysystem/LibrarySystemApplication.java
+++ b/src/main/java/com/book/librarysystem/LibrarySystemApplication.java
@@ -2,8 +2,10 @@ package com.book.librarysystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class LibrarySystemApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/book/librarysystem/domains/book/domain/Book.java
+++ b/src/main/java/com/book/librarysystem/domains/book/domain/Book.java
@@ -1,0 +1,41 @@
+package com.book.librarysystem.domains.book.domain;
+
+import java.time.LocalDateTime;
+
+import com.book.librarysystem.domains.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tbl_book")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Book extends BaseEntity{
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "book_id")
+	private Long id;
+
+	@Column(length = 255, nullable = false)
+	private String title;
+
+	@Column(length = 100, nullable = false)
+	private String author;
+
+	private LocalDateTime publishedAt;
+
+	private String modifiedBy;
+	private String deletedBy;
+
+	private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/book/librarysystem/domains/common/BaseEntity.java
+++ b/src/main/java/com/book/librarysystem/domains/common/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.book.librarysystem.domains.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@Column(updatable = false)
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@Column @LastModifiedDate
+	private LocalDateTime updatedAt;
+
+
+}

--- a/src/main/java/com/book/librarysystem/domains/loan/domain/Loan.java
+++ b/src/main/java/com/book/librarysystem/domains/loan/domain/Loan.java
@@ -1,0 +1,39 @@
+package com.book.librarysystem.domains.loan.domain;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tbl_loan")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Loan {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private LocalDate loanDate;
+	@Column(nullable = false)
+	private LocalDate dueDate;
+	private LocalDate returnDate;
+
+	@Column(length = 10)
+	private String status;
+
+	@Column(name = "book_id", nullable = false)
+	private Long bookId;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+}

--- a/src/main/java/com/book/librarysystem/domains/user/domain/User.java
+++ b/src/main/java/com/book/librarysystem/domains/user/domain/User.java
@@ -1,0 +1,33 @@
+package com.book.librarysystem.domains.user.domain;
+
+import com.book.librarysystem.domains.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tbl_user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_id")
+	private Long id;
+
+	@Column(length = 100, nullable = false)
+	private String name;
+
+	@Column(length = 255, nullable = false, unique = true)
+	private String email;
+
+	private boolean isAdministrator;
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     defer-datasource-initialization: false
-    hibernate.ddl-auto:
+    hibernate.ddl-auto: create
     show-sql: true
     properties:
       hibernate.format_sql: true


### PR DESCRIPTION
# 도서 관리 기본 도메인 설계
비즈니스 로직에 들어가기 앞서 기본 도메인을 설계하였습니다.
중복되는 컬럼의 경우 BaseEntity를 생성하여 상속 받았습니다.
생성일자 수정일자의 경우 audit 기능을 사용하였습니다.

# 참고문서
[erd](https://www.erdcloud.com/d/CCFo2geihEFk63KGZ)