### PR TITLE
캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.github.codemonstur:embedded-redis:1.4.2'
     // Dev
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     // Swagger

--- a/src/main/java/com/book/librarysystem/LibrarySystemApplication.java
+++ b/src/main/java/com/book/librarysystem/LibrarySystemApplication.java
@@ -2,7 +2,9 @@ package com.book.librarysystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class LibrarySystemApplication {
 

--- a/src/main/java/com/book/librarysystem/apis/book/api/BookController.java
+++ b/src/main/java/com/book/librarysystem/apis/book/api/BookController.java
@@ -17,6 +17,7 @@ import com.book.librarysystem.applications.book.BookService;
 import com.book.librarysystem.applications.book.request.BookDeleteRequest;
 import com.book.librarysystem.applications.book.request.BookRegisterRequest;
 import com.book.librarysystem.applications.book.request.BookUpdateRequest;
+import com.book.librarysystem.applications.book.response.BookDetailResponse;
 import com.book.librarysystem.applications.book.response.BookResponse;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,8 +41,8 @@ public class BookController implements BookControllerSpec {
 
 	@Override
 	@GetMapping("/{id}")
-	public ResponseEntity<BookResponse> getBook(@PathVariable Long id) {
-		BookResponse book = bookService.findById(id);
+	public ResponseEntity<BookDetailResponse> getBook(@PathVariable Long id) {
+		BookDetailResponse book = bookService.findById(id);
 		return ResponseEntity.ok(book);
 	}
 

--- a/src/main/java/com/book/librarysystem/apis/book/spec/BookControllerSpec.java
+++ b/src/main/java/com/book/librarysystem/apis/book/spec/BookControllerSpec.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import com.book.librarysystem.applications.book.request.BookDeleteRequest;
 import com.book.librarysystem.applications.book.request.BookRegisterRequest;
 import com.book.librarysystem.applications.book.request.BookUpdateRequest;
+import com.book.librarysystem.applications.book.response.BookDetailResponse;
 import com.book.librarysystem.applications.book.response.BookResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,7 +48,7 @@ public interface BookControllerSpec {
 		}
 	)
 	@GetMapping("/{id}")
-	ResponseEntity<BookResponse> getBook(
+	ResponseEntity<BookDetailResponse> getBook(
 		@Parameter(description = "조회할 도서 ID", example = "1") @PathVariable Long id
 	);
 

--- a/src/main/java/com/book/librarysystem/applications/book/BookService.java
+++ b/src/main/java/com/book/librarysystem/applications/book/BookService.java
@@ -3,6 +3,8 @@ package com.book.librarysystem.applications.book;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,7 @@ public class BookService {
 	private final BookRepository bookRepository;
 
 	@Transactional
+	@CacheEvict(cacheNames = "books", allEntries = true)
 	public Long registerBook(BookRegisterRequest request) {
 		Book book = request.toBook();
 		book = bookRepository.save(book);
@@ -31,6 +34,7 @@ public class BookService {
 	}
 
 	@Transactional
+	@CacheEvict(cacheNames = "books", allEntries = true)
 	public void updateBook(Long id, BookUpdateRequest request) {
 		Book book = getBook(id);
 		book.updateBook(request.title(), request.author(), DateTimeConverter.parseDate(request.publicationDate()),
@@ -39,6 +43,7 @@ public class BookService {
 	}
 
 	@Transactional
+	@CacheEvict(cacheNames = "books", allEntries = true)
 	public void deleteBook(Long id, BookDeleteRequest request) {
 		Book book = getBook(id);
 		book.deleteBook(request.deleteBy());
@@ -46,6 +51,7 @@ public class BookService {
 	}
 
 	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "books", key = "'all'")
 	public List<BookResponse> getAllBooks() {
 		List<Book> books = bookRepository.findAll();
 		return books.stream()
@@ -54,6 +60,7 @@ public class BookService {
 	}
 
 	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "books", key = "#id")
 	public BookResponse findById(Long id) {
 		return BookResponse.from(getBook(id));
 	}

--- a/src/main/java/com/book/librarysystem/applications/book/BookService.java
+++ b/src/main/java/com/book/librarysystem/applications/book/BookService.java
@@ -50,7 +50,6 @@ public class BookService {
 		bookRepository.save(book);
 	}
 
-	@Transactional(readOnly = true)
 	@Cacheable(cacheNames = "books", key = "'all'")
 	public List<BookResponse> getAllBooks() {
 		List<Book> books = bookRepository.findAll();
@@ -59,7 +58,6 @@ public class BookService {
 			.collect(Collectors.toList());
 	}
 
-	@Transactional(readOnly = true)
 	@Cacheable(cacheNames = "books", key = "#id")
 	public BookResponse findById(Long id) {
 		return BookResponse.from(getBook(id));

--- a/src/main/java/com/book/librarysystem/applications/book/BookService.java
+++ b/src/main/java/com/book/librarysystem/applications/book/BookService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.book.librarysystem.applications.book.request.BookDeleteRequest;
 import com.book.librarysystem.applications.book.request.BookRegisterRequest;
 import com.book.librarysystem.applications.book.request.BookUpdateRequest;
+import com.book.librarysystem.applications.book.response.BookDetailResponse;
 import com.book.librarysystem.applications.book.response.BookResponse;
 import com.book.librarysystem.domains.book.domain.Book;
 import com.book.librarysystem.domains.book.exception.BookNotFoundException;
@@ -59,8 +60,8 @@ public class BookService {
 	}
 
 	@Cacheable(cacheNames = "books", key = "#id")
-	public BookResponse findById(Long id) {
-		return BookResponse.from(getBook(id));
+	public BookDetailResponse findById(Long id) {
+		return BookDetailResponse.from(getBook(id));
 	}
 
 	public Book getBook(Long id) {

--- a/src/main/java/com/book/librarysystem/applications/book/response/BookDetailResponse.java
+++ b/src/main/java/com/book/librarysystem/applications/book/response/BookDetailResponse.java
@@ -1,0 +1,34 @@
+package com.book.librarysystem.applications.book.response;
+
+import java.io.Serializable;
+
+import com.book.librarysystem.domains.book.domain.Book;
+import com.book.librarysystem.globals.util.DateTimeConverter;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "도서 조회 응답 Response")
+public record BookDetailResponse(
+	@Schema(description = "도서 ID", example = "1")
+	Long id,
+	@Schema(description = "도서 제목", example = "자바의 정석")
+	String title,
+	@Schema(description = "도서 저자", example = "남궁성")
+	String author,
+	@Schema(description = "도서 출판일", example = "2021-01-01")
+	String publicationDate,
+	@Schema(description = "도서 삭제자", example = "admin")
+	String deletedBy,
+	@Schema(description = "도서 삭제일", example = "2021-01-01")
+	String deletedAt,
+	@Schema(description = "도서 수정자", example = "admin")
+	String modifiedBy
+
+) implements Serializable {
+	public static BookDetailResponse from(Book book) {
+		String publicationDate = DateTimeConverter.formatDate(book.getPublishedAt());
+		String deletedAt = DateTimeConverter.formatDateTime(book.getDeletedAt());
+		return new BookDetailResponse(book.getId(), book.getTitle(), book.getAuthor(), publicationDate, deletedAt,
+			book.getDeletedBy(), book.getModifiedBy());
+	}
+}

--- a/src/main/java/com/book/librarysystem/applications/book/response/BookResponse.java
+++ b/src/main/java/com/book/librarysystem/applications/book/response/BookResponse.java
@@ -1,5 +1,7 @@
 package com.book.librarysystem.applications.book.response;
 
+import java.io.Serializable;
+
 import com.book.librarysystem.domains.book.domain.Book;
 import com.book.librarysystem.globals.util.DateTimeConverter;
 
@@ -15,7 +17,7 @@ public record BookResponse(
 	String author,
 	@Schema(description = "도서 출판일", example = "2021-01-01")
 	String publicationDate
-) {
+) implements Serializable {
 	public static BookResponse from(Book book) {
 		String publicationDate = DateTimeConverter.formatDate(book.getPublishedAt());
 		return new BookResponse(book.getId(), book.getTitle(), book.getAuthor(), publicationDate);

--- a/src/main/java/com/book/librarysystem/globals/config/ApiDocsConfig.java
+++ b/src/main/java/com/book/librarysystem/globals/config/ApiDocsConfig.java
@@ -1,4 +1,4 @@
-package com.book.librarysystem.config;
+package com.book.librarysystem.globals.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/book/librarysystem/globals/config/JpaConfig.java
+++ b/src/main/java/com/book/librarysystem/globals/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.book.librarysystem.config;
+package com.book.librarysystem.globals.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/book/librarysystem/globals/config/RedisConfig.java
+++ b/src/main/java/com/book/librarysystem/globals/config/RedisConfig.java
@@ -1,0 +1,60 @@
+package com.book.librarysystem.globals.config;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
+	@Value("${spring.data.redis.password}")
+	private String redisPassword;
+
+	@Bean
+	LettuceConnectionFactory connectionFactory() {
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+		if (redisPassword != null && !redisPassword.isEmpty()) {
+			config.setPassword(RedisPassword.of(redisPassword));
+		}
+		return new LettuceConnectionFactory(config);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory());
+		return template;
+	}
+
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+		RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofMinutes(5))
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.disableCachingNullValues();
+
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.cacheDefaults(defaultCacheConfig).build();
+	}
+
+}

--- a/src/main/java/com/book/librarysystem/globals/config/RedisConfig.java
+++ b/src/main/java/com/book/librarysystem/globals/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -17,9 +18,8 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import lombok.val;
-
 @Configuration
+@Profile({"prod", "dev"})
 public class RedisConfig {
 	@Value("${spring.data.redis.host}")
 	private String redisHost;
@@ -58,6 +58,5 @@ public class RedisConfig {
 		return RedisCacheManager.builder(redisConnectionFactory)
 			.cacheDefaults(defaultCacheConfig).build();
 	}
-
 
 }

--- a/src/main/java/com/book/librarysystem/globals/config/RedisConfig.java
+++ b/src/main/java/com/book/librarysystem/globals/config/RedisConfig.java
@@ -17,6 +17,8 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import lombok.val;
+
 @Configuration
 public class RedisConfig {
 	@Value("${spring.data.redis.host}")
@@ -47,7 +49,7 @@ public class RedisConfig {
 	@Bean
 	public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
 		RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(Duration.ofMinutes(5))
+			.entryTtl(Duration.ofMinutes(10))
 			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
 			.serializeValuesWith(
 				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
@@ -56,5 +58,6 @@ public class RedisConfig {
 		return RedisCacheManager.builder(redisConnectionFactory)
 			.cacheDefaults(defaultCacheConfig).build();
 	}
+
 
 }

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,8 @@
+spring:
+  cache:
+    type: redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
     group:
-      dev: "dev, docs"
-      prod: "prod"
+      dev: "dev, docs, redis"
+      prod: "prod, redis"
     active: dev

--- a/src/test/java/com/book/librarysystem/apis/book/api/BookControllerTest.java
+++ b/src/test/java/com/book/librarysystem/apis/book/api/BookControllerTest.java
@@ -15,6 +15,7 @@ import com.book.librarysystem.apis.ControllerTestSupport;
 import com.book.librarysystem.applications.book.request.BookDeleteRequest;
 import com.book.librarysystem.applications.book.request.BookRegisterRequest;
 import com.book.librarysystem.applications.book.request.BookUpdateRequest;
+import com.book.librarysystem.applications.book.response.BookDetailResponse;
 import com.book.librarysystem.applications.book.response.BookResponse;
 import com.book.librarysystem.fixtures.book.BookFixture;
 
@@ -78,7 +79,7 @@ class BookControllerTest extends ControllerTestSupport {
 	@Test
 	@DisplayName("성공: ID로 도서를 조회하면 정보를 반환한다.")
 	void getBookById() throws Exception {
-		BookResponse response = BookFixture.bookResponse;
+		BookDetailResponse response = BookFixture.bookDetailResponse;
 		given(bookService.findById(1L)).willReturn(response);
 
 		mockMvc.perform(get("/api/book/{id}", 1L))

--- a/src/test/java/com/book/librarysystem/applications/ServiceTestSupport.java
+++ b/src/test/java/com/book/librarysystem/applications/ServiceTestSupport.java
@@ -1,11 +1,15 @@
 package com.book.librarysystem.applications;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
+
+import com.book.librarysystem.globals.config.RedisTestConfig;
 
 import jakarta.transaction.Transactional;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import(RedisTestConfig.class)
 @Transactional
 @Sql("/truncate.sql")
 public abstract class ServiceTestSupport {

--- a/src/test/java/com/book/librarysystem/applications/book/BookServiceTest.java
+++ b/src/test/java/com/book/librarysystem/applications/book/BookServiceTest.java
@@ -13,6 +13,7 @@ import com.book.librarysystem.applications.ServiceTestSupport;
 import com.book.librarysystem.applications.book.request.BookDeleteRequest;
 import com.book.librarysystem.applications.book.request.BookRegisterRequest;
 import com.book.librarysystem.applications.book.request.BookUpdateRequest;
+import com.book.librarysystem.applications.book.response.BookDetailResponse;
 import com.book.librarysystem.applications.book.response.BookResponse;
 import com.book.librarysystem.domains.book.domain.Book;
 import com.book.librarysystem.domains.book.exception.BookNotFoundException;
@@ -48,7 +49,7 @@ class BookServiceTest extends ServiceTestSupport {
 		BookUpdateRequest updateRequest = BookFixture.bookUpdateRequest;
 		bookService.updateBook(bookId, updateRequest);
 
-		BookResponse response = bookService.findById(bookId);
+		BookDetailResponse response = bookService.findById(bookId);
 		assertThat(response.title()).isEqualTo(updateRequest.title());
 		assertThat(response.author()).isEqualTo(updateRequest.author());
 		String expectedPublicationDate = DateTimeConverter.formatDate(
@@ -82,8 +83,9 @@ class BookServiceTest extends ServiceTestSupport {
 			BookRegisterRequest request = BookFixture.bookRegisterRequest;
 			Long bookId = bookService.registerBook(request);
 
-			BookResponse response = bookService.findById(bookId);
-			assertThat(response).extracting(BookResponse::id, BookResponse::title, BookResponse::author)
+			BookDetailResponse response = bookService.findById(bookId);
+			assertThat(response).extracting(BookDetailResponse::id, BookDetailResponse::title,
+					BookDetailResponse::author)
 				.containsExactly(bookId, request.title(), request.author());
 		}
 

--- a/src/test/java/com/book/librarysystem/fixtures/book/BookFixture.java
+++ b/src/test/java/com/book/librarysystem/fixtures/book/BookFixture.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.book.librarysystem.applications.book.request.BookDeleteRequest;
 import com.book.librarysystem.applications.book.request.BookRegisterRequest;
 import com.book.librarysystem.applications.book.request.BookUpdateRequest;
+import com.book.librarysystem.applications.book.response.BookDetailResponse;
 import com.book.librarysystem.applications.book.response.BookResponse;
 
 public final class BookFixture {
@@ -29,6 +30,10 @@ public final class BookFixture {
 
 	public static final BookResponse bookResponse2 = new BookResponse(
 		2L, "스프링 부트 인 액션", "김영한", "2022-03-01"
+	);
+
+	public static final BookDetailResponse bookDetailResponse = new BookDetailResponse(
+		1L, "자바의 정석", "남궁성", "2021-01-01", "2021-01-01", "admin", null
 	);
 	public static final List<BookResponse> bookResponses = List.of(
 		bookResponse, bookResponse2

--- a/src/test/java/com/book/librarysystem/globals/config/RedisTestConfig.java
+++ b/src/test/java/com/book/librarysystem/globals/config/RedisTestConfig.java
@@ -1,0 +1,46 @@
+package com.book.librarysystem.globals.config;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import redis.embedded.RedisServer;
+
+@Configuration
+public class RedisTestConfig {
+
+	private static RedisServer redisServer;
+
+	@PostConstruct
+	public void startRedis() throws IOException {
+		if (redisServer == null || !redisServer.isActive()) {
+			redisServer = new RedisServer(6379);
+			redisServer.start();
+		}
+	}
+
+	@PreDestroy
+	public void stopRedis() throws IOException {
+		if (redisServer != null) {
+			redisServer.stop();
+		}
+	}
+
+	@Bean
+	@Primary
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		return template;
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,3 +13,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
     show-sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
# 캐싱 적용

## 적용 엔드포인트
1. 도서 목록 조회 API (GET /api/book)
이유
- 데이터 변경이 적은 빈도로 발생
- 사용자가 자주 조회하는 데이터
전략
- todo 페이징, 정렬 조건에 따른 캐시 키 구성
- 데이터 변경 시 키 무효화
2. 도서 상세 조회 API (GET /api/book/{id})
이유
- 변경 빈도가 적고 자주 조회하는 데이터
전략
- id를 키값으로 잡아 조회 결과 저장
- 도서 수정 삭제 캐시 무효화


## 캐싱 전략
1. TTL
5분으로 설정하여 최신 데이터를 반영하도록 노력
2.분산 캐시 관리
다중 인스턴스 환경에서 캐시 일관성을 유지하기 위해 redis 글로벌 캐시 사용

## 성능 테스트
postman runner collection을 통해 간단하게 수행
목록 조회 API를 100번 실행한 평균 시간
캐싱 적용 전
![image](https://github.com/user-attachments/assets/d38ac75d-1766-4e02-8f95-dd0931b35a35)
80ms
적용 후
![image](https://github.com/user-attachments/assets/4e77f361-336f-4c2a-a853-0146129b2089)
28ms

## 정확성 검증
캐싱 적용하여 단건 조회한 경우
삭제 전
![image](https://github.com/user-attachments/assets/cc330e49-1a3a-44a0-a23b-4da37edb02db)
삭제 API 작동
![image](https://github.com/user-attachments/assets/aea4d75a-4911-490e-b188-bd79c4625d5e)

DB와 캐시 데이터가 정확한걸 확인 할 수 있습니다.
