### PR TITLE
feat : cd 워크플로우 생성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - release
+  pull_request:
+    branches:
+      - release
 
 jobs:
   build-docker-image:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Run new container
         run: |
           sudo docker run -it -d --restart always --name library-app -p 8080:8080 \
+            --network library_network \
             -e SPRING_PROFILES_ACTIVE=prod \
             -e SPRING_DATASOURCE_URL=${{ secrets.DB_URL }} \
             -e SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME }} \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,8 +66,6 @@ jobs:
             -e SPRING_DATASOURCE_URL=${{ secrets.DB_URL }} \
             -e SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME }} \
             -e SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD }} \
-            -e SPRING_REDIS_HOST=${{ secrets.REDIS_HOST }} \
-            -e SPRING_REDIS_PORT=${{ secrets.REDIS_PORT }} \
             ${{ secrets.DOCKER_USERNAME }}/library-system:latest
 
       - name: Cleanup old images

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,71 @@
+name: backend deploy to release
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test
+
+      - name: Build Docker Image
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/library-system:latest .
+
+      - name: Push Docker Image
+        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+      - run: docker push ${{ secrets.DOCKER_USERNAME }}/library-system:latest
+
+  deploy-to-ec2:
+    needs: build-docker-image
+    runs-on: self-hosted
+
+    steps:
+      - name: Pull latest Docker image
+        run: sudo docker pull ${{ secrets.DOCKER_USERNAME }}/library-system:latest
+
+      - name: Stop existing container
+        run: |
+          if [ $(sudo docker ps -q -f name=library-app) ]; then
+            sudo docker stop library-app
+          fi
+
+      - name: Remove old container
+        run: |
+          if [ $(sudo docker ps -a -q -f name=library-app) ]; then
+            sudo docker rm library-app
+          fi
+
+      - name: Run new container
+        run: |
+          sudo docker run -it -d --restart always --name library-app -p 8080:8080 \
+            -e SPRING_PROFILES_ACTIVE=prod \
+            -e SPRING_DATASOURCE_URL=${{ secrets.DB_URL }} \
+            -e SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME }} \
+            -e SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD }} \
+            -e SPRING_REDIS_HOST=${{ secrets.REDIS_HOST }} \
+            -e SPRING_REDIS_PORT=${{ secrets.REDIS_PORT }} \
+            ${{ secrets.DOCKER_USERNAME }}/library-system:latest
+
+      - name: Cleanup old images
+        run: sudo docker system prune -f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         run: ./gradlew clean build
         env:
           SPRING_PROFILES_ACTIVE: test
+          SPRING_DATASOURCE_URL: ${{ secrets.DB_URL }}
+          SPRING_DATASOURCE_USERNAME: ${{ secrets.DB_USERNAME }}
+          SPRING_DATASOURCE_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          SPRING_REDIS_HOST: ${{ secrets.REDIS_HOST }}
+          SPRING_REDIS_PORT: ${{ secrets.REDIS_PORT }}
 
       - name: Write Test Report
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+COPY build/libs/librarySystem-0.0.1-SNAPSHOT.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      idle-timeout: 30000
+      max-lifetime: 600000
+      connection-timeout: 30000
+
+  jpa:
+    defer-datasource-initialization: false
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+  sql:
+    init:
+      mode: never
+
+  logging:
+    level:
+      org.hibernate.SQL: error  # ❌ Hibernate SQL 로그 출력하지 않음
+      org.hibernate.type.descriptor.sql.BasicBinder: error

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -3,6 +3,6 @@ spring:
     type: redis
   data:
     redis:
-      host: ${REDIS_HOST}
+      host: localhost
       port: 6379
       password: redis

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -3,6 +3,6 @@ spring:
     type: redis
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
       password: redis

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -3,6 +3,6 @@ spring:
     type: redis
   data:
     redis:
-      host: localhost
+      host: ${REDIS_HOST}
       port: 6379
       password: redis


### PR DESCRIPTION
# CD 워크플로우 생성
기본 요구사항을 모두 개발하여 CD를 구축하여 서버에 배포하였습니다.
http://43.201.99.191:8080/swagger-ui/index.html

## prod 환경
prod 환경을 구성하기 위해 application-prod를 생성하였고 민감한 정보들은 github secrets를 활용하여 관리하였습니다.

## 기술 스택
github actions : CI 워크플로우를 해당 기술스택을 사용하여 구축하였기 때문에 간단하고 빠르게 구축할 수 있는 github actions를 선택하였습니다.
docker : 한 서버내에 library 시스템과 redis, 모니터링 서버까지 띄울 예정이기 때문에 docker 를 선택하여습니다.
github runners : 시크릿키를 사용하더라도 ssh를 직접 연결하는건 보안적으로 위험도가 있다고 판단하여 runners를 통해 연결하였습니다.

## todo
https 설정


